### PR TITLE
Fix setup.py for windows system!

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,13 @@ exec(open(f_version).read())
 # Get the long description from the relevant file
 description = "Images filters learned from Instagram. Implemented in pytorch."
 
-with open("README.md") as FIN:
-    long_description = FIN.read()
+long_description = None
+if os.name == 'nt':
+    with open("README.md", encoding="utf8") as FIN:
+        long_description = FIN.read()
+else:
+    with open("README.md") as FIN:
+        long_description = FIN.read()
 
 
 setuptools.setup(


### PR DESCRIPTION
The library installation was giving an error for windows system, The error was 
```
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [8 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "C:\Users\dadga\AppData\Local\Temp\pip-install-uxpepd04\instafilter_c7836e83f40c4fde8cfd36fbf3c9622f\setup.py", line 16, in <module>
          long_description = FIN.read()
        File "C:\Users\dadga\miniconda3\envs\ec-final-proj\lib\encodings\cp1252.py", line 23, in decode
          return codecs.charmap_decode(input,self.errors,decoding_table)[0]
      UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 1214: character maps to <undefined>
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```
So to fix it, we could simply change the reading encoding of `README.md` to `utf8`. 